### PR TITLE
Remove types added by accident

### DIFF
--- a/src/t/index.d.ts
+++ b/src/t/index.d.ts
@@ -1,7 +1,0 @@
-declare module 'lodash' {
-  function chunk(array: string[], size?: number): string[]
-
-  function chunk(array: number[], size?: number): number[]
-
-  function chunk(array: boolean[], size?: number): boolean[]
-}


### PR DESCRIPTION
PR does what it says, removes the types I added while demonstrating to @rgomezp.